### PR TITLE
fix: update responseHandler on change

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ Per Authorize.net's [Accept.js documentation](https://developer.authorize.net/ap
    };
 
    const App = () => {
-     const handleSubmit = (response) => {
+     const handleSubmit = React.useCallback((response) => {
        console.log('Received response:', response);
-     };
+     }, []);
      return <HostedForm authData={authData} onSubmit={handleSubmit} />;
    };
 

--- a/src/HostedForm/HostedForm.tsx
+++ b/src/HostedForm/HostedForm.tsx
@@ -52,7 +52,7 @@ const HostedForm = ({
   );
 
   React.useEffect(() => {
-    if (!scriptError && !loading && !window.responseHandler)
+    if (!scriptError && !loading)
       window.responseHandler = responseHandler;
     if (scriptError)
       setErrors(


### PR DESCRIPTION
the issue with current implementation is once the handler is registered, it does't get updated if any state is changed in the parent component.
Propose changes make sure when the `onChange` method gets changed it updates the `window.responseHandler`, so the `responseHandler` always gets the updated value.

We this would force users, to use a useCallback on the onChange method to avoid unnecessary updates.