### PR TITLE
remove deprecated scrolling from iframe

### DIFF
--- a/src/AcceptHosted/IFrameIntegration/IFrameIntegration.tsx
+++ b/src/AcceptHosted/IFrameIntegration/IFrameIntegration.tsx
@@ -243,7 +243,6 @@ export const IFrame = ({ className, style }: CompoundComponentCommonProps) => {
       name="iframeAuthorizeNet"
       id="iframeAuthorizeNet"
       frameBorder="0"
-      scrolling="no"
       width="100%"
       height="100%"
       className={className}


### PR DESCRIPTION
The problem was not being able to add scrolling to the hosted iframe. 

The proposed changes remove the attribute `scrolling` from the iframe. 

The result is that the scrolling functionality resides in the customizable style attribute `overflow` rather than the `scrolling` attribute. 

Thanks!