### PR TITLE
feat: use new useDynamicScript hook in HostedForm

### DIFF
--- a/src/HostedForm/HostedForm.tsx
+++ b/src/HostedForm/HostedForm.tsx
@@ -5,7 +5,7 @@ import {
   HostedFormResponseHandlerFn,
   ErrorMessage,
 } from '../types';
-import useScript from '../hooks/useScript';
+import useDynamicScript from '../hooks/useDynamicScript';
 
 const HostedForm = ({
   authData,
@@ -29,7 +29,7 @@ const HostedForm = ({
     environment === 'PRODUCTION'
       ? 'https://js.authorize.net/v3/AcceptUI.js'
       : 'https://jstest.authorize.net/v3/AcceptUI.js';
-  const [scriptLoaded, scriptError] = useScript(scriptUrl);
+  const [scriptLoaded, scriptError] = useDynamicScript(scriptUrl);
 
   React.useEffect(() => {
     if (scriptLoaded || scriptError) {

--- a/src/hooks/useDynamicScript.ts
+++ b/src/hooks/useDynamicScript.ts
@@ -1,0 +1,56 @@
+import * as React from 'react';
+
+/**
+ * `useDynamicScript()` is similar to `useScript()` - the key difference
+ * being `useDynamicScript()` will remove the `<script>` tag from the DOM
+ * before the component is removed.
+ */
+function useDynamicScript(
+  url: string,
+  async = true,
+  appendToHeadOrBody: 'head' | 'body' = 'head'
+) {
+  const [state, setState] = React.useState({
+    loaded: false,
+    error: false,
+  });
+
+  React.useEffect(() => {
+    const script = document.createElement('script');
+    script.src = url;
+    script.async = async;
+
+    const onScriptLoad = () => {
+      setState({
+        loaded: true,
+        error: false,
+      });
+    };
+
+    const onScriptError = () => {
+      script.remove();
+
+      setState({
+        loaded: true,
+        error: true,
+      });
+    };
+
+    script.addEventListener('load', onScriptLoad);
+    script.addEventListener('error', onScriptError);
+
+    appendToHeadOrBody === 'head'
+      ? document.head.appendChild(script)
+      : document.body.appendChild(script);
+
+    return () => {
+      script.removeEventListener('load', onScriptLoad);
+      script.removeEventListener('error', onScriptError);
+      script.remove();
+    };
+  }, [url, async, appendToHeadOrBody]);
+
+  return [state.loaded, state.error];
+}
+
+export default useDynamicScript;


### PR DESCRIPTION
Fixes #5.

# Explanation

The problem: The dynamic nature of React means components will be loaded & unloaded from the DOM as a user navigates a single-page application.

The [docs for Accept.js](https://developer.authorize.net/api/reference/features/acceptjs.html) state:
>If you are building your page dynamically, be sure that your page loads the Accept JavaScript library after the button is defined. For the library to correctly interface with the button, the button must already exist in the DOM when the library is loaded.

This requirement is most likely due to needing to attach an event listener to the button to launch the hosted form. When a user navigates to another part of the SPA that unloaded `<HostedForm />`, that event listener breaks.

The (admittedly hacky) solution is to remove `AcceptUI.js` from the DOM when `<HostedForm />` is unloaded. Navigating back to the page with the `<HostedForm />` will add the script back to the DOM, allowing usage of `<HostedForm />` without a hard refresh.

# Changes

A new hook, `useDynamicScript()`, was added. It's similar to `useScript()` but will remove the `<script>` tag containing `AcceptUI.js` when the component containing the hook is unloaded.

# Caveats

The initial plan was to `fetch()` the script so we could inject the script text into a `<script>` tag ourselves to prevent additional network requests. However, the lack of any CORS policy defined on `https://js.authorize.net` prevents this.

The script itself is only 5.8KB so it shouldn't be too painful to reload the script for each usage.